### PR TITLE
Feature/40 UI question sets page category field

### DIFF
--- a/src/components/TagList.tsx
+++ b/src/components/TagList.tsx
@@ -1,18 +1,15 @@
 import { Tag } from 'antd';
 import React from 'react';
 
+import { Category } from '../services/ApiClient';
 import { colorByCategory } from '../services/tagCategoryColorService';
 
-export default function TagList({
-  categories,
-}: {
-  categories: string[];
-}): JSX.Element {
+export default function TagList({ tags }: { tags: Category[] }): JSX.Element {
   return (
     <div>
-      {categories.map((category) => (
-        <Tag key={category} color={colorByCategory(category)}>
-          {category}
+      {tags.map((tag) => (
+        <Tag key={tag.title} color={colorByCategory(tag.title ?? '')}>
+          {tag.title}
         </Tag>
       ))}
     </div>

--- a/src/domain/QuestionList/QuestionListCard/QuestionListCardLarge.tsx
+++ b/src/domain/QuestionList/QuestionListCard/QuestionListCardLarge.tsx
@@ -11,7 +11,7 @@ import { QuestionListCardLargeProps } from './QuestionListCardLargeProps';
 export default function QuestionListCardLarge(
   props: QuestionListCardLargeProps
 ): JSX.Element {
-  const { list, categories, onCardClickedCallback, moreIconContent } = props;
+  const { list, tags, onCardClickedCallback, moreIconContent } = props;
 
   const averageDifficultyContentElement = (
     percent: number | undefined
@@ -38,7 +38,7 @@ export default function QuestionListCardLarge(
             <h3>{list.questionSet?.title}</h3>
             <span>By Anonymous</span>
           </Space>
-          <TagList categories={categories} />
+          <TagList tags={tags} />
         </div>
       </Col>
       <Col span={2}>

--- a/src/domain/QuestionList/QuestionListCard/QuestionListCardLargeProps.tsx
+++ b/src/domain/QuestionList/QuestionListCard/QuestionListCardLargeProps.tsx
@@ -1,10 +1,10 @@
 import { MouseEventHandler } from 'react';
 
-import { QuestionSetListItem } from '../../../services/Client';
+import { Category, QuestionSetListItem } from '../../../services/Client';
 
 export interface QuestionListCardLargeProps {
   list: QuestionSetListItem;
-  categories: string[];
+  tags: Category[];
   onCardClickedCallback: MouseEventHandler;
   moreIconContent: JSX.Element;
 }

--- a/src/domain/QuestionList/QuestionListCard/QuestionListCardSmall.tsx
+++ b/src/domain/QuestionList/QuestionListCard/QuestionListCardSmall.tsx
@@ -7,7 +7,7 @@ import { QuestionListCardSmallProps } from './QuestionListCardSmallProps';
 export default function QuestionListCardSmall(
   props: QuestionListCardSmallProps
 ): JSX.Element {
-  const { list, categories, onCardClickedCallback } = props;
+  const { list, tags, onCardClickedCallback } = props;
 
   return (
     <div
@@ -20,7 +20,7 @@ export default function QuestionListCardSmall(
     >
       <h4>{list.questionSet?.title}</h4>
 
-      <TagList categories={categories} />
+      <TagList tags={tags} />
     </div>
   );
 }

--- a/src/domain/QuestionList/QuestionListCard/QuestionListCardSmallProps.tsx
+++ b/src/domain/QuestionList/QuestionListCard/QuestionListCardSmallProps.tsx
@@ -1,9 +1,9 @@
 import { MouseEventHandler } from 'react';
 
-import { QuestionSetListItem } from '../../../services/Client';
+import { Category, QuestionSetListItem } from '../../../services/Client';
 
 export interface QuestionListCardSmallProps {
   list: QuestionSetListItem;
-  categories: string[];
+  tags: Category[];
   onCardClickedCallback: MouseEventHandler;
 }

--- a/src/pages/QuestionListsPage/QuestionLists.tsx
+++ b/src/pages/QuestionListsPage/QuestionLists.tsx
@@ -19,8 +19,6 @@ import {
 } from '../../services/Client';
 import { filterLists } from '../../services/filterService';
 
-const exampleCategories = ['C#', 'SQL', 'Java'];
-
 export default function QuestionLists(): JSX.Element {
   const client = new Client();
   const navigate = useNavigate();
@@ -107,7 +105,7 @@ export default function QuestionLists(): JSX.Element {
           <div className="centered">
             <QuestionListCardSmall
               list={list}
-              categories={exampleCategories}
+              tags={list.tags ?? []}
               onCardClickedCallback={() =>
                 navigate(`QuestionList/${list.questionSet?.id}`)
               }
@@ -131,7 +129,7 @@ export default function QuestionLists(): JSX.Element {
           <div className="centered">
             <QuestionListCardLarge
               list={list}
-              categories={exampleCategories}
+              tags={list.tags ?? []}
               onCardClickedCallback={() =>
                 navigate(`QuestionList/${list.questionSet?.id}`)
               }

--- a/src/services/ApiClient.ts
+++ b/src/services/ApiClient.ts
@@ -573,9 +573,45 @@ export class ApiClient {
     }
 }
 
+export class Category implements ICategory {
+    title?: string | undefined;
+
+    constructor(data?: ICategory) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.title = _data["title"];
+        }
+    }
+
+    static fromJS(data: any): Category {
+        data = typeof data === 'object' ? data : {};
+        let result = new Category();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["title"] = this.title;
+        return data;
+    }
+}
+
+export interface ICategory {
+    title?: string | undefined;
+}
+
 export class CreateQuestionRequest implements ICreateQuestionRequest {
     title!: string;
-    difficulty?: number | undefined;
+    difficulty!: number;
     category!: string;
     content!: string;
 
@@ -616,7 +652,7 @@ export class CreateQuestionRequest implements ICreateQuestionRequest {
 
 export interface ICreateQuestionRequest {
     title: string;
-    difficulty?: number | undefined;
+    difficulty: number;
     category: string;
     content: string;
 }
@@ -872,6 +908,7 @@ export interface IQuestionSetDetail {
 export class QuestionSetListItem implements IQuestionSetListItem {
     questionSet?: QuestionSetModel;
     difficulty?: Difficulty;
+    tags?: Category[] | undefined;
 
     constructor(data?: IQuestionSetListItem) {
         if (data) {
@@ -886,6 +923,11 @@ export class QuestionSetListItem implements IQuestionSetListItem {
         if (_data) {
             this.questionSet = _data["questionSet"] ? QuestionSetModel.fromJS(_data["questionSet"]) : <any>undefined;
             this.difficulty = _data["difficulty"] ? Difficulty.fromJS(_data["difficulty"]) : <any>undefined;
+            if (Array.isArray(_data["tags"])) {
+                this.tags = [] as any;
+                for (let item of _data["tags"])
+                    this.tags!.push(Category.fromJS(item));
+            }
         }
     }
 
@@ -900,6 +942,11 @@ export class QuestionSetListItem implements IQuestionSetListItem {
         data = typeof data === 'object' ? data : {};
         data["questionSet"] = this.questionSet ? this.questionSet.toJSON() : <any>undefined;
         data["difficulty"] = this.difficulty ? this.difficulty.toJSON() : <any>undefined;
+        if (Array.isArray(this.tags)) {
+            data["tags"] = [];
+            for (let item of this.tags)
+                data["tags"].push(item.toJSON());
+        }
         return data;
     }
 }
@@ -907,6 +954,7 @@ export class QuestionSetListItem implements IQuestionSetListItem {
 export interface IQuestionSetListItem {
     questionSet?: QuestionSetModel;
     difficulty?: Difficulty;
+    tags?: Category[] | undefined;
 }
 
 export class QuestionSetModel implements IQuestionSetModel {


### PR DESCRIPTION
## Summary

The QuestionSet includes tags corresponding to categories for list of questions. There is replaced name category by tag which is more general. We will able to use this component for different type of tags. Maybe it could be user roles in the future and even if there will exist title and color it is more or less tag (no category).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change to code and structure)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notes

We have already discussed what kind of naming is better (tag or category). As you can see there is used mainly tag on FE side (is more general) and I suppose it make sense. Even if the class Category received from BE doesn't look good, it could be useful in case another type of tag e.g. user role, because we could allow more types of tags.
